### PR TITLE
修复PDF大纲跳转错位问题，新增附录自动ABCD编号

### DIFF
--- a/njupthesis.cls
+++ b/njupthesis.cls
@@ -632,8 +632,6 @@
     \renewcommand{\theequation}{\thechapter-\arabic{equation}}
     \renewcommand{\thetable}{\thechapter-\arabic{table}}
     \renewcommand{\thefigure}{\thechapter-\arabic{figure}}
-    % 添加到目录
-    \addcontentsline{toc}{chapter}{附录\thechapter}
     % 设置章节标题格式
     \titleformat{\chapter}[block]
     {\fontsize{16pt}{16pt}\selectfont\heiti\thispagestyle{fancy}}
@@ -643,6 +641,10 @@
     \chapter*{\raggedleft\fontsize{16pt}{16pt}\selectfont{附录\thechapter}}
     \thispagestyle{fancy}
     \markboth{附录\thechapter}{附录\thechapter}
+    % 添加到目录
+    \addcontentsline{toc}{chapter}{附录\thechapter}
+    % 附录和附录正文添加空行
+    \vspace{0.5cm}
 }
 
 % 定理推导等等翻译

--- a/njupthesis.cls
+++ b/njupthesis.cls
@@ -608,26 +608,37 @@
 }
 
 % 附录
+% 定义一个计数器用于附录编号（实现自动ABC编号）
+\newcounter{appendixcounter}
+\setcounter{appendixcounter}{0}
+
+% 定义附录环境
 \newcommand{\thesisappendix}{
-	\titleformat{\chapter}[block]
-	{\fontsize{16pt}{16pt}\selectfont\heiti\thispagestyle{fancy}}
-	{\thechapter}{30pt}{}
-	\titlespacing{\chapter}{0pt}{0pt}{0pt}
-	
-    \chapter*{\raggedleft\fontsize{16pt}{16pt}\selectfont{附录A}}
-  	
-  	\titleformat{\chapter}[block]
-  	{\centering\fontsize{15pt}{15pt}\selectfont\heiti\thispagestyle{fancy}}
-  	{\thechapter}{30pt}{}
-  	\titlespacing{\chapter}{0pt}{0pt}{15pt}
-  	
+    % 增加附录计数器
+    \stepcounter{appendixcounter}
+    % 重置章节编号
+    \setcounter{chapter}{0}
     \setcounter{section}{0}
-    \addcontentsline{toc}{chapter}{附录}
-    \markboth{附录}{附录}
+    \setcounter{equation}{0}
+    \setcounter{table}{0}
+    \setcounter{figure}{0}
+    % 重置章节编号格式
+    \renewcommand{\thechapter}{\Alph{appendixcounter}}
+    \renewcommand{\thesection}{\thechapter-\arabic{section}}
+    \renewcommand{\theequation}{\thechapter-\arabic{equation}}
+    \renewcommand{\thetable}{\thechapter-\arabic{table}}
+    \renewcommand{\thefigure}{\thechapter-\arabic{figure}}
+    % 添加到目录
+    \addcontentsline{toc}{chapter}{附录\thechapter}
+    % 设置章节标题格式
+    \titleformat{\chapter}[block]
+    {\fontsize{16pt}{16pt}\selectfont\heiti\thispagestyle{fancy}}
+    {\thechapter}{30pt}{}
+    \titlespacing{\chapter}{0pt}{0pt}{0pt}
+    % 添加附录标题
+    \chapter*{\raggedleft\fontsize{16pt}{16pt}\selectfont{附录\thechapter}}
     \thispagestyle{fancy}
-    \renewcommand{\theequation}{a-\arabic{equation}}
-    \renewcommand{\thetable}{a-\arabic{table}}
-    \renewcommand{\thefigure}{a-\arabic{figure}}
+    \markboth{附录\thechapter}{附录\thechapter}
 }
 
 % 定理推导等等翻译

--- a/njupthesis.cls
+++ b/njupthesis.cls
@@ -627,11 +627,12 @@
     \setcounter{table}{0}
     \setcounter{figure}{0}
     % 重置章节编号格式
+    \renewcommand{\theHchapter}{Appendix\Alph{appendixcounter}.\arabic{chapter}} % 超链接锚点唯一标识
     \renewcommand{\thechapter}{\Alph{appendixcounter}}
-    \renewcommand{\thesection}{\thechapter-\arabic{section}}
-    \renewcommand{\theequation}{\thechapter-\arabic{equation}}
-    \renewcommand{\thetable}{\thechapter-\arabic{table}}
-    \renewcommand{\thefigure}{\thechapter-\arabic{figure}}
+    \renewcommand{\thesection}{\thechapter.\arabic{section}}
+    \renewcommand{\theequation}{\thechapter.\arabic{equation}}
+    \renewcommand{\thetable}{\thechapter.\arabic{table}}
+    \renewcommand{\thefigure}{\thechapter.\arabic{figure}}
     % 设置章节标题格式
     \titleformat{\chapter}[block]
     {\fontsize{16pt}{16pt}\selectfont\heiti\thispagestyle{fancy}}
@@ -641,8 +642,9 @@
     \chapter*{\raggedleft\fontsize{16pt}{16pt}\selectfont{附录\thechapter}}
     \thispagestyle{fancy}
     \markboth{附录\thechapter}{附录\thechapter}
-    % 添加到目录
-    \addcontentsline{toc}{chapter}{附录\thechapter}
+    % 添加到PDF目录
+    \phantomsection % 手动设置PDF大纲
+    \addcontentsline{toc}{chapter}{附录\thechapter} % 手动添加附录X的PDF大纲
     % 附录和附录正文添加空行
     \vspace{0.5cm}
 }

--- a/njupthesis.cls
+++ b/njupthesis.cls
@@ -341,6 +341,8 @@
     \chapter*{\fontsize{16pt}{16pt}\selectfont{摘\chinesespace\chinesespace 要}}
     \thispagestyle{empty}
     \vspace{1cm}
+}{
+  \clearpage
 }
 
 % 中文关键字
@@ -360,6 +362,8 @@
   \pdfbookmark{英文摘要}{englishabstract}
   \chapter*{\fontsize{16pt}{16pt}\selectfont{\bfseries ABSTRACT}}
     \thispagestyle{empty}
+}{
+  \clearpage
 }
 
 % 英文关键字


### PR DESCRIPTION
### 修改项一

如题，目前附录写死了`附录A`，新增一个计数器让附录可以被多次插入，实现自动编号成ABCD。

额外调整：附录中子标题样式调整为B.1，并在附录标题和正文之间添加0.5cm空行。

直接在原有附录后继续添加`\thesisappendix`插入新的附录即可

```latex
\thesisappendix

\section{本科期间的获奖情况}
\begin{itemize}
	\item 设计了一块RTX5090
	\item 准备移民火星
	\item 去太阳上面看看
\end{itemize}
```

效果截图：

![image](https://github.com/user-attachments/assets/eaaf9855-e70d-41f2-9e90-e03e94ac6177)

同时修复了原始方案中附录自动编号后附录中的section跳转错位问题，比如`附录B.1`会跳转到`附录A.1`的问题。

以下为演示GIF，附录A和附录B的所有大纲都能正常跳转。

![test](https://github.com/user-attachments/assets/e9d4448d-28a8-418e-b047-34f2b4807240)

----

### 修改项二

给中文摘要和英文摘要添加了`\clearpage`，用于解决中文摘要、英文摘要、目录的PDF大纲跳转错位问题（在我的环境中英文摘要会跳转到中文摘要末尾，目录会跳转到英文摘要末尾）。


